### PR TITLE
Handle ties for 25th place more intelligently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,3 @@ __pycache__
 db.sqlite3
 /.idea
 /Poll Data.ods
-.vscode
-rcfbpoll.dump
-Pipfile
-Pipfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ __pycache__
 db.sqlite3
 /.idea
 /Poll Data.ods
+.vscode
+Pipfile
+Pipfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ __pycache__
 db.sqlite3
 /.idea
 /Poll Data.ods
+.vscode
+rcfbpoll.dump
+Pipfile
+Pipfile.lock

--- a/poll/views.py
+++ b/poll/views.py
@@ -24,8 +24,8 @@ def home(request):
     most_recent_poll = polls[0]
 
     ranks = PollCompare.objects.filter(poll=most_recent_poll).order_by('rank')
-    top25 = ranks[0:25]
-    others = ranks[25:]
+    top25 = ranks.filter(rank__lte=25)
+    others = ranks.filter(rank__gt=25)
     up_movers = ranks.order_by('-ppv_diff')[0:5]
     down_movers = ranks.order_by('ppv_diff')[0:5]
 
@@ -39,7 +39,7 @@ def home(request):
     dropped = []
     prev_poll = most_recent_poll.last_week
     if prev_poll is not None:
-        prev_top25 = PollCompare.objects.filter(poll=prev_poll).order_by('rank')[0:25]
+        prev_top25 = PollCompare.objects.filter(poll=prev_poll, rank__lte=25).order_by('rank')
 
         teams = []
         for team in top25:
@@ -316,8 +316,8 @@ def view_poll(request, pk):
         return HttpResponseForbidden()
 
     ranks = PollCompare.objects.filter(poll=poll).order_by('rank')
-    top25 = ranks[0:25]
-    others = ranks[25:]
+    top25 = ranks.filter(rank__lte=25)
+    others = ranks.filter(rank__gt=25)
     up_movers = ranks.order_by('-ppv_diff')[0:5]
     down_movers = ranks.order_by('ppv_diff')[0:5]
 


### PR DESCRIPTION
This change takes advantage of Django's `QuerySet`'s [`Field` lookups](https://docs.djangoproject.com/en/1.9/ref/models/querysets/#field-lookups) by filtering the `ranks` object. The change affects the `home` and `view_poll` views in `view.py`.